### PR TITLE
Library does not compile when used in C

### DIFF
--- a/include/mgos_arduino_bme280.h
+++ b/include/mgos_arduino_bme280.h
@@ -8,7 +8,11 @@
 #ifndef CS_MOS_LIBS_ARDUINO_ADAFRUIT_BME280_SRC_MGOS_ARDUINO_BME280_H_
 #define CS_MOS_LIBS_ARDUINO_ADAFRUIT_BME280_SRC_MGOS_ARDUINO_BME280_H_
 
+#ifdef __cplusplus
 #include "Adafruit_BME280.h"
+#else
+typedef struct Adafruit_BME280Tag Adafruit_BME280;
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
When trying to use in C, the build process throws errors:
deps/arduino-adafruit-bme280/include/Adafruit_BME280.h:125:1: error: unknown type name 'class'
deps/arduino-adafruit-bme280/include/mgos_arduino_bme280.h:29:1: error: unknown type name 'Adafruit_BME280'
